### PR TITLE
adjusting for earlier Chrome versions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,12 @@
 {
   "name": "Design Mode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Edit a webpage's text",
-  "permissions": ["storage", "activeTab"],
+  "minimum_chrome_version": "45",
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
   "browser_action": {
     "default_title": "Enable Design Mode"
   },
@@ -13,7 +17,9 @@
     "128": "images/cursor128.png"
   },
   "background": {
-    "scripts": ["src/background.js"],
+    "scripts": [
+      "src/background.js"
+    ],
     "persistent": false
   },
   "manifest_version": 2

--- a/src/toggleDesignMode.js
+++ b/src/toggleDesignMode.js
@@ -1,3 +1,17 @@
 'use strict';
 
-document.designMode = document.designMode === 'on' ? 'off' : 'on';
+function getChromeVersion () {     
+  var raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+  return raw ? parseInt(raw[2], 10) : 0;
+}
+
+// Before Chrome 64, designMode was accessed through the HTMLDocument alias.
+// designMode doesn't exist before 45
+// https://developer.mozilla.org/en-US/docs/Web/API/Document/designMode#Browser_compatibility
+if (getChromeVersion() < 64) {
+  HTMLDocument.designMode = HTMLDocument.designMode === 'on' ? 'off' : 'on';
+} else {
+  document.designMode = document.designMode === 'on' ? 'off' : 'on';
+}
+


### PR DESCRIPTION
* designMode doesn't exist before 45
* Before Chrome 64, designMode was accessed through the HTMLDocument alias.